### PR TITLE
fix: support GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="./vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Application de Suivi d&#39;Investissements Boursiers</title>
   </head>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,9 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  // Use relative paths so the app can be served from GitHub Pages
+  // or any subdirectory without broken asset links
+  base: './',
   optimizeDeps: {
     exclude: ['lucide-react'],
   },


### PR DESCRIPTION
## Summary
- ensure relative asset paths for GitHub Pages
- fix favicon path in index

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1ae20a22c833398e7a497e90ba09e